### PR TITLE
fix: Added delay to make sure that device is ready

### DIFF
--- a/pkg/v2/command/command.go
+++ b/pkg/v2/command/command.go
@@ -51,7 +51,6 @@ type RemoteData struct {
 // recreate a complete protobuf message from multiple chunks
 // each new message is sent to handleData
 func (c *Command) processData(read_size int, size_to_read int, buffer *[]byte, total_data *[]byte) int {
-
 	if read_size < size_to_read {
 		// not enough data
 		size_to_read -= read_size
@@ -153,6 +152,9 @@ func (c *Command) Connect() error {
 	go c.readLoop()
 
 	c.sendConfiguration()
+
+	// wait for the device to be ready
+	time.Sleep(time.Millisecond * 100)
 
 	return nil
 }

--- a/pkg/v2/command/command.go
+++ b/pkg/v2/command/command.go
@@ -154,7 +154,7 @@ func (c *Command) Connect() error {
 	c.sendConfiguration()
 
 	// wait for the device to be ready
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Millisecond * 500)
 
 	return nil
 }


### PR DESCRIPTION
Closes: #2 

Based on the implementation of [androidtv-remote](https://github.com/louis49/androidtv-remote), a short delay is required after sending configuration message to the TV